### PR TITLE
H5py file lock fix for newer h5py versions.

### DIFF
--- a/net_plotter.py
+++ b/net_plotter.py
@@ -8,6 +8,7 @@ from os.path import exists, commonprefix
 import h5py
 import h5_util
 import model_loader
+import os
 
 ################################################################################
 #                 Supporting functions for weights manipulation
@@ -230,6 +231,10 @@ def setup_direction(args, dir_file, net):
     print('-------------------------------------------------------------------')
     print('setup_direction')
     print('-------------------------------------------------------------------')
+    
+    # Setup env for preventing lock on h5py file for newer h5py versions
+    os.environ["HDF5_USE_FILE_LOCKING"] = "FALSE"
+    
     # Skip if the direction file already exists
     if exists(dir_file):
         f = h5py.File(dir_file, 'r')


### PR DESCRIPTION
So newer versions of h5py throw the following error when ``f = h5py.File(surf_file, 'r+' if rank == 0 else 'r')`` is called:
```
OSError: Unable to open file (unable to lock file, errno = 11, error message = 'Resource temporarily unavailable')
```

This fix prevents this error from happening and the project can run on newer versions of h5py. This will also finally fix issue https://github.com/tomgoldstein/loss-landscape/issues/4 . 